### PR TITLE
Goci 2863 ds summary stats release fix

### DIFF
--- a/ftpSummaryStatsScript/README.md
+++ b/ftpSummaryStatsScript/README.md
@@ -14,7 +14,12 @@ A Python script to copy summary statistics files from the staging folders to the
 ### Usage
 
 ```bash
-python ftp_data_release.py --releaseDB ${database} --stagingDir ${stagingDir} --ftpDir ${ftpDir} --emailRecipient ${email}
+python ftp_data_release.py \
+    --releaseDB ${database} \
+    --stagingDir ${stagingDir} \
+    --ftpDir ${ftpDir} \
+    --emailRecipient ${email} \
+    --test
 ```
 
 **Parameters:**
@@ -22,6 +27,7 @@ python ftp_data_release.py --releaseDB ${database} --stagingDir ${stagingDir} --
 * *releaseDB* : instance name for the release database. This instance should only contain published studies
 * *stagingDir* : directory where curators copy summary stats files until the corresponding study is published
 * *ftpDir* : directory where the released data will be copyied
+* *test* : flag to indicate test run. If test run is specified, no action is taken, just a report is sent.
 
 ### More information
 

--- a/ftpSummaryStatsScript/ftp_data_release.py
+++ b/ftpSummaryStatsScript/ftp_data_release.py
@@ -345,14 +345,14 @@ if __name__ == '__main__':
         exit(0)
 
     # Rename folders where study ID is given instead of accession ID
-    # renameFolders(summaryStatsFoldersObj.stagingFoldersToRename,stagingDir)
+    renameFolders(summaryStatsFoldersObj.stagingFoldersToRename,stagingDir)
 
     # Generate md5sum checksum for folders to be copied:
     for folder in summaryStatsFoldersObj.foldersToCopy:
         generate_md5_sum('{}/{}'.format(stagingDir,folder))
 
     # Copy folders to ftp:
-    # copyFoldersToFtp(summaryStatsFoldersObj.foldersToCopy, stagingDir, ftpDir)
+    copyFoldersToFtp(summaryStatsFoldersObj.foldersToCopy, stagingDir, ftpDir)
 
     # # Folders are no longer retracted from ftp:
     # retractFolderFromFtp(summaryStatsFoldersObj.ftpFoldersToRemove, ftpDir)


### PR DESCRIPTION
Two minor improvement in the summary stats release script:
* User can start a test run, where the report is generated and sent, but no action is taken (to enable this feature call the script with the `--test` flag.)
* If a folder is missing from the staging area a report is generated even if no study was released. (This feature is important for diagnostic purposes: a failure in the directory naming can remain under the radar if there's no notification)