### PR TITLE
LSF job report fix

### DIFF
--- a/solr_indexer_manager/components/lsf_manager.py
+++ b/solr_indexer_manager/components/lsf_manager.py
@@ -85,6 +85,15 @@ class LSF_manager(object):
     def kill_job(self, jobID):
         x = Popen(['bkill', jobID], stdout=PIPE, stderr=PIPE)
 
+        # Parse output:
+        output = x.communicate()
+        stdout = output[0]
+        stderr = output[1]
+    
+        if stdout:
+            print(stdout)
+        if stderr:
+            print(stderr)
 
     def check_job(self,jobID):
         x = Popen(['bjobs', '-a', jobID], stdout=PIPE, stderr=PIPE)

--- a/solr_indexer_manager/components/lsf_manager.py
+++ b/solr_indexer_manager/components/lsf_manager.py
@@ -82,6 +82,9 @@ class LSF_manager(object):
                 'working_dir' : workingDir, 
                 'job_name' : jobname
             })
+    def kill_job(self, jobID):
+        x = Popen(['bkill', jobID], stdout=PIPE, stderr=PIPE)
+
 
     def check_job(self,jobID):
         x = Popen(['bjobs', '-a', jobID], stdout=PIPE, stderr=PIPE)
@@ -136,9 +139,16 @@ class LSF_manager(object):
         ## Delete failed jobs form list, kill the process and re-submit them:
         ##
         if jobs_to_delete:
-            # Re-submit jobs:
+
             for index in jobs_to_delete:
+
+                # Extract job details:
                 job = self.jobs[index]
+
+                # Kill job:
+                self.kill_job(job['job_id'])
+
+                # Resubmit job:
                 self.submit_job(command = job['command'], workingDir = job['working_dir'], jobname = job['job_name'])
 
             # Remove failed jobs:

--- a/solr_indexer_manager/dummy_script.sh
+++ b/solr_indexer_manager/dummy_script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+
+# Generate sleep time:
+sleepTime=$(shuf -i 10-100 -n 1)
+
+# Generate exit code:
+exitStatus=0
+if [[ ${sleepTime: -1} -eq 0 || ${sleepTime: -1} -eq 5 ]]; then 
+    exitStatus=1;
+fi
+
+# This script doesn/t do anything. It mimics running the indexer application.
+t1=$(date '+%H:%m:%S')
+echo "[Info] Starting process at ${t1}"
+echo "[Info] Passed parameters: $*"
+echo "[Info] sleep time: ${sleepTime}"
+echo "[Info] Exit code: ${exitStatus}"
+
+sleep ${sleepTime}
+
+t2=$(date '+%H:%m:%S')
+echo "[Info] Ending process at ${t2}"
+
+exit $exitStatus
+

--- a/solr_indexer_manager/indexer_manager.py
+++ b/solr_indexer_manager/indexer_manager.py
@@ -67,15 +67,12 @@ def manage_lsf_jobs(job_list, workingDir):
         for status, count in report.items():
             print("\t{}: {}".format(status, count))
 
-        if 'RUN' not in report and 'PEND' not in report:
+        if 'RUN' not in report and 'PEND' not in report and 'EXIT' not in report:
             print('[Info] No running or pending jobs were found. Exiting.')
             break
 
-        time.sleep(1800)
+        time.sleep(10)
 
-    # Having this means all the jobs are finished:
-    report = LSF_obj.generate_report()
-    return report
 
 if __name__ == '__main__':
 
@@ -99,6 +96,9 @@ if __name__ == '__main__':
     
     # Location for log files:
     parser.add_argument('--logFolder', help='Folder into which the log files will be generated.')
+
+    # Print out excessive reports:
+    parser.add_argument('--verbose', help='Flag to give more informative output.', action = "store_true")
     args = parser.parse_args()
 
     # Parser out database instance names:
@@ -110,6 +110,7 @@ if __name__ == '__main__':
     solrCore = args.solrCore
     solrPort = args.solrPort
     fullIndex = args.fullIndex
+    verbose = args.verbose
 
     # Parse wrapper:
     wrapperScript = args.wrapperScript
@@ -139,11 +140,11 @@ if __name__ == '__main__':
 
     # Generate a list of jobs:
     joblist = job_generator(db_updates, wrapperScript)
-    print(joblist)
 
     # Print reports before submit to farm:
-    print('[Info] List of jobs to be submitted to the farm:')
-    print('\n\t'.join(joblist.values()))
+    if verbose:
+        print('[Info] List of jobs to be submitted to the farm:')
+        print('\n\t'.join(joblist.values()))
 
     # Submitting the jobs to the farm:
     manage_lsf_jobs(joblist, logDir)

--- a/solr_indexer_manager/indexer_manager.py
+++ b/solr_indexer_manager/indexer_manager.py
@@ -71,7 +71,7 @@ def manage_lsf_jobs(job_list, workingDir):
             print('[Info] No running or pending jobs were found. Exiting.')
             break
 
-        time.sleep(10)
+        time.sleep(600)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Modeifications in this branch:**
* `lsf_manager.py`: function fixed to manage running jobs based on the exit statuses. If a job fails, or it's become unresponsive, the script kills the job, then re-submits.
* `indexer_manager.py`: lsf commands are written only if `--verbose` flag submitted. Running jobs are checked every 10 minutes.
* Extra file: `dummy_script.sh` a dummy script that might be useful for testing purposes. It mimics the behaviour of the indexing application. Prints out the received command line parameters, randomly decides the exit code (with 20% chance to exit with 1; 80% to exit with 0). Exits after a randomly selected waiting time (10-100sec).

**LSF reports**:
There are 5 jobs, so far one finished, 4 are still running:
```
[Info] Checking statuses of the submitted jobs at: Jan 13 22:46
	RUN: 4
	DONE: 1
```
One of the job failed, tried to killed based on the jobID, then resubmitted:
```
[Warning] A job (id: 1842528) was found with EXIT status. The job is killed and re-submitted to the farm.
b'Job <1842528>: Job has already finished\n'
[Info] Job has been successfully submitted. Job ID: 1842966
[Info] Checking statuses of the submitted jobs at: Jan 13 22:46
	DONE: 3
	EXIT: 1
	RUN: 1
```
No job listed with `EXIT` status as that job was deleted from object, and was resubmitted.
```
[Info] Checking statuses of the submitted jobs at: Jan 13 22:46
	DONE: 3
	RUN: 2
```