### PR TITLE
fix: Remove size-only option for ftp-sync

### DIFF
--- a/ftpSummaryStatsScript/depo_ftp_to_staging.py
+++ b/ftpSummaryStatsScript/depo_ftp_to_staging.py
@@ -22,9 +22,9 @@ logger = logging.getLogger(__name__)
 # number of seconds since modification that a file should be left alone
 # in case of latency for writing the file.
 
-# MOD_THRESHOLD_SEC = 3600 
+MOD_THRESHOLD_SEC = 3600 
 # DEV ONLY
-MOD_THRESHOLD_SEC = 36
+# MOD_THRESHOLD_SEC = 36
 RANGE_SIZE = 1000
 
 

--- a/ftpSummaryStatsScript/depo_ftp_to_staging.py
+++ b/ftpSummaryStatsScript/depo_ftp_to_staging.py
@@ -22,9 +22,9 @@ logger = logging.getLogger(__name__)
 # number of seconds since modification that a file should be left alone
 # in case of latency for writing the file.
 
-MOD_THRESHOLD_SEC = 3600 
+# MOD_THRESHOLD_SEC = 3600 
 # DEV ONLY
-# MOD_THRESHOLD_SEC = 36
+MOD_THRESHOLD_SEC = 36
 RANGE_SIZE = 1000
 
 

--- a/ftpSummaryStatsScript/ftp_sync.py
+++ b/ftpSummaryStatsScript/ftp_sync.py
@@ -303,10 +303,9 @@ class SummaryStatsSync:
             # -p - preserve permissions
             # -v - verbose
             # -h - human readable output
-            # --size-only - only file size is compared, timestamp is ignored
             # --exclude=".*" - excluding hidden files
             logger.info("Sync {} --> {}".format(source, dest))
-            subprocess.call(['rsync', '-rpvh', '--chmod=Du=rwx,Dg=rwx,Do=rx,Fu=rw,Fg=rw,Fo=r', '--size-only', '--exclude=.*', source, dest])
+            subprocess.call(['rsync', '-rpvh', '--chmod=Du=rwx,Dg=rwx,Do=rx,Fu=rw,Fg=rw,Fo=r', '--exclude=.*', source, dest])
         except OSError as e:
             logger.error(e)
 


### PR DESCRIPTION
This pull request removes the `size-only` option from `ftp-sync`. We identified scenarios where files, such as metadata YAML files, are generated with identical sizes. The presence of the `size-only` option previously led to these files not being synchronized to the public FTP server due to size matching, despite content differences.